### PR TITLE
Add allDifferent and isAscending haskell implementations

### DIFF
--- a/Haskell/allDifferent.hs
+++ b/Haskell/allDifferent.hs
@@ -1,0 +1,5 @@
+-- Recursively checks if every item in a List is different or not
+allDifferent :: Eq a => [a] -> Bool
+allDifferent [] = True
+allDifferent [_] = True
+allDifferent (x:xs) = (notElem x xs) && (allDifferent xs)

--- a/Haskell/isAscending.hs
+++ b/Haskell/isAscending.hs
@@ -1,0 +1,3 @@
+isAscending :: (Ord a) => [a] -> Bool
+isAscending xs = and [ x <= y | (x,y) <- zip xs (tail xs) ]
+


### PR DESCRIPTION
This PR adds two _Haskell_ functions: `allDifferent` and `isAscending`.
* `allDifferent`: Given a list of items, recursively checks if every item in the list is different nor not using patterns.
* `isAscending`: Given a list of orderable items, checks if it is ordered in ascending order using zip and list comprehensions